### PR TITLE
Model tiering: sonnet for mechanical skills, inherit session for quality-sensitive

### DIFF
--- a/skill-sources/graph/SKILL.md
+++ b/skill-sources/graph/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Grep, Glob, Bash
 argument-hint: "[operation] [target] — operations: health, triangles, bridges, clusters, hubs, siblings, forward, backward, query"
 ---

--- a/skill-sources/learn/SKILL.md
+++ b/skill-sources/learn/SKILL.md
@@ -4,7 +4,6 @@ description: Research a topic and grow your knowledge graph. Uses Exa deep resea
 user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__exa__web_search_exa, mcp__exa__deep_researcher_start, mcp__exa__deep_researcher_check, WebSearch
 context: fork
-model: opus
 ---
 
 ## EXECUTE NOW

--- a/skill-sources/next/SKILL.md
+++ b/skill-sources/next/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Grep, Glob, Bash
 ---
 

--- a/skill-sources/pipeline/SKILL.md
+++ b/skill-sources/pipeline/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 argument-hint: "[file] — path to source file to process end-to-end"
 ---

--- a/skill-sources/ralph/SKILL.md
+++ b/skill-sources/ralph/SKILL.md
@@ -5,7 +5,6 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, Task
 argument-hint: "N [--parallel] [--batch id] [--type extract] [--dry-run] — N = number of tasks to process"
 ---
@@ -60,10 +59,9 @@ Each phase maps to specific Task tool parameters. Use these EXACTLY when spawnin
 
 **All phases use the same subagent configuration:**
 - subagent_type: knowledge-worker (if available) or default
-- model: opus
 - mode: dontAsk
 
-**Why opus for all phases:** Tokens are free, quality is not. Fresh context per phase already ensures efficiency — every phase gets full capability in the smart zone.
+Subagents inherit the session model. Users running opus get opus quality on processing phases. Users running sonnet get sonnet everywhere. Fresh context per phase already ensures efficiency — every phase gets full capability in the smart zone.
 
 ---
 

--- a/skill-sources/reduce/SKILL.md
+++ b/skill-sources/reduce/SKILL.md
@@ -6,7 +6,6 @@ generated_from: "arscontexta-v1.6"
 user-invocable: true
 allowed-tools: Read, Write, Grep, Glob, mcp__qmd__vector_search
 context: fork
-model: opus
 ---
 
 ## Runtime Configuration (Step 0 — before any processing)

--- a/skill-sources/refactor/SKILL.md
+++ b/skill-sources/refactor/SKILL.md
@@ -5,7 +5,6 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 argument-hint: "[dimension|--dry-run] — focus on specific dimension or preview without approval prompt"
 ---

--- a/skill-sources/reflect/SKILL.md
+++ b/skill-sources/reflect/SKILL.md
@@ -4,7 +4,6 @@ description: Find connections between notes and update MOCs. Requires semantic j
 user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__qmd__search, mcp__qmd__vector_search, mcp__qmd__deep_search, mcp__qmd__status
 context: fork
-model: opus
 ---
 
 ## Runtime Configuration (Step 0 — before any processing)

--- a/skill-sources/remember/SKILL.md
+++ b/skill-sources/remember/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 ---
 

--- a/skill-sources/rethink/SKILL.md
+++ b/skill-sources/rethink/SKILL.md
@@ -4,7 +4,6 @@ description: Challenge system assumptions against accumulated evidence. Triages 
 user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion
 context: fork
-model: opus
 ---
 
 ## Runtime Configuration (Step 0 — before any processing)

--- a/skill-sources/reweave/SKILL.md
+++ b/skill-sources/reweave/SKILL.md
@@ -4,7 +4,6 @@ description: Update old notes with new connections. The backward pass that /refl
 user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, mcp__qmd__search, mcp__qmd__vector_search, mcp__qmd__deep_search, mcp__qmd__status
 context: fork
-model: opus
 ---
 
 ## Runtime Configuration (Step 0 — before any processing)

--- a/skill-sources/seed/SKILL.md
+++ b/skill-sources/seed/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 argument-hint: "[file] — path to source file to seed for processing"
 ---

--- a/skill-sources/stats/SKILL.md
+++ b/skill-sources/stats/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Grep, Glob, Bash
 argument-hint: "[--share] — optional flag for compact shareable output"
 ---

--- a/skill-sources/tasks/SKILL.md
+++ b/skill-sources/tasks/SKILL.md
@@ -5,7 +5,7 @@ version: "1.0"
 generated_from: "arscontexta-v1.6"
 user-invocable: true
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash
 argument-hint: "[add|done|drop|reorder|status] [description|number] — manage task stack and view queue"
 ---

--- a/skill-sources/verify/SKILL.md
+++ b/skill-sources/verify/SKILL.md
@@ -4,7 +4,6 @@ description: Combined verification — recite (description quality via cold-read
 user-invocable: true
 allowed-tools: Read, Write, Edit, Grep, Glob, mcp__qmd__vector_search
 context: fork
-model: opus
 ---
 
 ## Runtime Configuration (Step 0 — before any processing)

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -2,7 +2,7 @@
 name: setup
 description: Scaffold a complete knowledge system. Detects platform, conducts conversation, derives configuration, generates everything. Validates against 15 kernel primitives. Triggers on "/setup", "/setup --advanced", "set up my knowledge system", "create my vault".
 context: fork
-model: opus
+model: sonnet
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 argument-hint: "[--advanced for upfront dimension configuration]"
 ---


### PR DESCRIPTION
## Summary

- **Force sonnet** on 9 mechanical/structured skills (stats, tasks, seed, graph, pipeline, next, remember, validate, setup) — these don't need opus-level reasoning
- **Remove model override** from 8 quality-sensitive skills (reduce, reflect, reweave, rethink, refactor, ralph, verify, learn) — these inherit the user's session model

## Rationale

Previously all skills forced `model: opus`. This created two problems:
- Sonnet users got unexpected model escalation
- Opus users spent opus tokens on tasks like counting files and managing checklists

The new approach:
- **Opus user** → saves tokens on mechanical skills (forced sonnet), gets opus quality on processing/reasoning skills (inherited)
- **Sonnet user** → everything runs on sonnet, no surprise escalation
- **User choice respected** — quality-sensitive skills follow the session model

## Affected skills

| Skill | Change | Reasoning |
|-------|--------|-----------|
| stats, tasks, seed | → sonnet | Metrics, CRUD, file management |
| graph, next | → sonnet | Structural analysis, threshold-based ranking |
| pipeline, remember | → sonnet | Orchestration, friction capture |
| validate, setup | → sonnet | Schema checks, onboarding |
| reduce, reflect, reweave | remove override | Semantic judgment compounds into knowledge graph |
| rethink, refactor | remove override | System-level reasoning and cascade planning |
| ralph, verify, learn | remove override | Queue processing, quality gating, research |

🤖 Generated with [Claude Code](https://claude.com/claude-code)