### PR TITLE
fix: session-orient hook crashes on Linux due to stat -f flag ambiguity

### DIFF
--- a/skill-sources/rethink/SKILL.md
+++ b/skill-sources/rethink/SKILL.md
@@ -86,9 +86,10 @@ Read:
 
 ```bash
 # Compare config.yaml modification time vs newest methodology note
-CONFIG_MTIME=$(stat -f %m ops/config.yaml 2>/dev/null || stat -c %Y ops/config.yaml 2>/dev/null || echo 0)
+# Linux stat -f means filesystem stats (not file), so try -c first
+CONFIG_MTIME=$(stat -c %Y ops/config.yaml 2>/dev/null || stat -f %m ops/config.yaml 2>/dev/null || echo 0)
 NEWEST_METH=$(ls -t ops/methodology/*.md 2>/dev/null | head -1)
-METH_MTIME=$(stat -f %m "$NEWEST_METH" 2>/dev/null || stat -c %Y "$NEWEST_METH" 2>/dev/null || echo 0)
+METH_MTIME=$(stat -c %Y "$NEWEST_METH" 2>/dev/null || stat -f %m "$NEWEST_METH" 2>/dev/null || echo 0)
 ```
 
 If `CONFIG_MTIME > METH_MTIME`: config has changed since methodology was last updated. Flag as staleness drift.

--- a/skills/health/SKILL.md
+++ b/skills/health/SKILL.md
@@ -407,7 +407,8 @@ for f in {vocabulary.notes}/*.md; do
   basename=$(basename "$f" .md)
 
   # Last modified (days ago)
-  mod_days=$(( ($(date +%s) - $(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null)) / 86400 ))
+  # Linux stat -f means filesystem stats (not file), so try -c first
+  mod_days=$(( ($(date +%s) - $(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)) / 86400 ))
 
   # Incoming link count
   incoming=$(rg -l "\[\[$basename\]\]" --glob '*.md' | grep -v "$f" | wc -l | tr -d ' ')


### PR DESCRIPTION
## Problem

The session-orient SessionStart hook crashes on Linux with an arithmetic syntax error at line 146. This causes a "SessionStart hook error" on every session start and resume.

The root cause is `stat -f %m` -- intended as macOS syntax to get file modification time. On Linux, `-f` is a valid flag meaning "filesystem stats" (statfs), so instead of failing and falling through to the `|| stat -c %Y` fallback, it succeeds and dumps multi-line filesystem info to stdout. That garbage then gets fed into a bash arithmetic expression, producing:

```sh
line 146: File: "ops/config.yaml" ... syntax error in expression
```

## Fix

- **hooks/scripts/session-orient.sh**: Detect the platform once by testing which `stat` syntax returns a valid mtime, trying Linux (`-c %Y`) first since `-f` is the ambiguous flag. Wraps the detection in a helper function to avoid repeating the logic.
- **skill-sources/rethink/SKILL.md**: Swap stat flag order to try Linux syntax first.
- **skills/health/SKILL.md**: Same fix.

## Testing

Tested on Ubuntu (Linux 6.17.0) where the hook was consistently failing.
Verified the hook completes successfully with exit code 0 after the fix.