### PR TITLE
Add disable_plugin_hooks config toggle

### DIFF
--- a/hooks/scripts/read_config.sh
+++ b/hooks/scripts/read_config.sh
@@ -5,6 +5,8 @@
 # Returns: value for key, or default if key/file missing.
 # Default default: "true" (preserves existing behaviour when no config exists).
 #
+# Supported keys: git, session_capture, disable_plugin_hooks
+#
 # Migration: old marker files (cat face text) have no YAML keys,
 # so grep returns nothing → defaults apply → behaviour unchanged.
 

--- a/hooks/scripts/vaultguard.sh
+++ b/hooks/scripts/vaultguard.sh
@@ -21,6 +21,11 @@ git: true
 session_capture: true
 EOF
   fi
+  # Check if plugin hooks are disabled
+  DISABLE_PLUGIN_HOOKS=$("$(dirname "$0")/read_config.sh" disable_plugin_hooks false)
+  if [ "$DISABLE_PLUGIN_HOOKS" = "true" ]; then
+    exit 1
+  fi
   exit 0
 fi
 
@@ -34,6 +39,11 @@ if [ -f ops/config.yaml ] || [ -f .claude/hooks/session-orient.sh ]; then
 git: true
 session_capture: true
 EOF
+  # Check if plugin hooks are disabled
+  DISABLE_PLUGIN_HOOKS=$("$(dirname "$0")/read_config.sh" disable_plugin_hooks false)
+  if [ "$DISABLE_PLUGIN_HOOKS" = "true" ]; then
+    exit 1
+  fi
   exit 0
 fi
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1531,8 +1531,9 @@ session_capture: true
 Keys and defaults:
 - `git: true` — auto-commit on writes (auto-commit.sh)
 - `session_capture: true` — session JSON capture on start (session-orient.sh)
+- `disable_plugin_hooks: false` — set to `true` to disable all plugin hooks (use when project-local hooks cover everything)
 
-Omitted keys default to `true`, so a minimal marker file (or even an empty file) preserves full default behaviour.
+Omitted keys default to `false` for `disable_plugin_hooks` and `true` for all others, so a minimal marker file (or even an empty file) preserves full default behaviour.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `disable_plugin_hooks` key to `.arscontexta` config
- When set to `true`, `vaultguard.sh` exits 1, skipping all plugin hooks
- Project-local hooks in `.claude/settings.json` are unaffected
- Addresses the conflict between plugin hooks and vaults that want full control via their own hooks

## Test plan

- [ ] In a vault with `disable_plugin_hooks: true`, run a plugin hook script directly — should exit silently
- [ ] In a vault with `disable_plugin_hooks: false` (or key absent), hooks run normally
- [ ] Project-local hooks in `.claude/settings.json` unaffected in both cases